### PR TITLE
Fix #3 - Trim whitespaces of rows generated in table body

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function renderDependencies(dependency) {
     license,
     dependencyType,
     '',
-  ].join(' | ');
+  ].join(' | ').trim();
 }
 
 module.exports = function DEPENDENCYTABLE(content, _options = {}, config) {


### PR DESCRIPTION
**Why:**

As reported in issue #3, the body of the dependency table is generated
with leading and trailing whitespaces. This generates errors when
linting the files using pre-commit hooks that prohibit trailing spaces.

**What:**

Trim every row, so the leading and trailing spaces are removed
correctly.